### PR TITLE
Fix active submenu state logic in Navigation component

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -34,20 +34,26 @@ const Navigation: React.FC<NavigationProps> = ({
   };
 
   const [isPeinturesNavOpen, setIsPeinturesNavOpen] = useState(
-    currentPath.startsWith("/series") &&
-      groupedSeries.peintures.some((s) => currentPath === `/series/${s.slug}`)
+    groupedSeries.peintures.some((s) => currentPath === `/series/${s.slug}`)
   );
   const [isDessinsNavOpen, setIsDessinsNavOpen] = useState(
-    currentPath.startsWith("/series") &&
-      groupedSeries.dessins.some((s) => currentPath === `/series/${s.slug}`)
+    groupedSeries.dessins.some((s) => currentPath === `/series/${s.slug}`)
   );
 
   useEffect(() => {
-    if (!currentPath.startsWith("/series")) {
+    if (currentPath.startsWith("/series")) {
+      // Keep the appropriate submenu open based on current series
+      const isPeintureActive = groupedSeries.peintures.some((s) => currentPath === `/series/${s.slug}`);
+      const isDessinActive = groupedSeries.dessins.some((s) => currentPath === `/series/${s.slug}`);
+      
+      setIsPeinturesNavOpen(isPeintureActive);
+      setIsDessinsNavOpen(isDessinActive);
+    } else {
+      // Close all submenus when not on a series page
       setIsPeinturesNavOpen(false);
       setIsDessinsNavOpen(false);
     }
-  }, [currentPath]);
+  }, [currentPath, groupedSeries]);
 
   return (
     <aside id="sidebar">


### PR DESCRIPTION
## Summary
- Corrects the logic for determining which navigation submenus are active based on the current path
- Ensures submenus for "Peintures" and "Dessins" only open when the current path matches a series slug
- Closes all submenus when not on a series page

## Changes

### Navigation Component
- Removed redundant `currentPath.startsWith("/series")` check from initial submenu open state
- Updated `useEffect` to:
  - Open the appropriate submenu if the current path matches a series slug in either "Peintures" or "Dessins"
  - Close all submenus if the current path is outside the `/series` route
- Added `groupedSeries` as a dependency to the effect to ensure submenu state updates correctly when series data changes

## Test plan
- Navigate to various series pages and verify the correct submenu is open
- Navigate away from series pages and verify all submenus are closed
- Confirm submenu state updates correctly when series data changes or current path changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4bc65438-e35d-43b0-9095-eec5c6680ed1